### PR TITLE
Improve download resilience

### DIFF
--- a/BSU.BSO/BsoRepoMod.cs
+++ b/BSU.BSO/BsoRepoMod.cs
@@ -174,6 +174,12 @@ namespace BSU.BSO
                     // Get the hash of the file, use the extension from the original path to use the PBO logic 
                     var entry = GetFileEntry(path) ?? throw new FileNotFoundException(path);
                     var partRead = await fileSystem.OpenRead(partPath, cancellationToken) ?? throw new FileNotFoundException(partPath);
+                    if ((ulong)partRead.Length != entry.FileSize)
+                    {
+                        await partRead.DisposeAsync();
+                        throw new InvalidDataException(
+                            $"Size mismatch for {path}. Expected {entry.FileSize}, got {(ulong)partRead.Length}.");
+                    }
                     var partHash = await Sha1AndPboHash.BuildAsync(partRead, Utils.GetExtension(path), cancellationToken);
                     var expectedHash = new Sha1AndPboHash(entry.Hash);
 
@@ -197,6 +203,14 @@ namespace BSU.BSO
             }
             catch (Exception e)
             {
+                try
+                {
+                    await fileSystem.Delete(partPath, CancellationToken.None);
+                }
+                catch
+                {
+                    // best effort cleanup of temp files
+                }
                 _logger.Error(e, $"Error while trying to download {partPath}");
                 throw;
             }

--- a/BSU.BSO/BsoRepoMod.cs
+++ b/BSU.BSO/BsoRepoMod.cs
@@ -23,11 +23,13 @@ namespace BSU.BSO
     internal class BsoRepoMod : IRepositoryMod
     {
         // TODO: re-use http clients?
+        private const int DefaultMaxTransferAttempts = 3;
 
         private readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         private readonly string _url;
         private readonly string? _expectedHash;
+        private readonly int _maxTransferAttempts;
         private HashFile? _hashFile;
         private readonly Task _loading;
         private readonly HttpClient _client = new();
@@ -69,10 +71,11 @@ namespace BSU.BSO
         private BsoFileHash? GetFileEntry(string path) =>
             _hashFile?.Hashes.SingleOrDefault(h => h.FileName.ToLowerInvariant() == path);
 
-        public BsoRepoMod(string url, string? expectedHash, IJobManager jobManager)
+        public BsoRepoMod(string url, string? expectedHash, IJobManager jobManager, int maxTransferAttempts = DefaultMaxTransferAttempts)
         {
             _url = url;
             _expectedHash = expectedHash;
+            _maxTransferAttempts = maxTransferAttempts > 0 ? maxTransferAttempts : DefaultMaxTransferAttempts;
             _loading = jobManager.Run($"Bso Repo Mod Load {_url}", () => Load(CancellationToken.None), CancellationToken.None);
         }
 
@@ -147,73 +150,39 @@ namespace BSU.BSO
 
         public async Task DownloadTo(string path, IFileSystem fileSystem, IProgress<ulong> progress, CancellationToken cancellationToken)
         {
-            
-            // TODO: retry
-            
             await _loading;
 
             var url = _url + GetRealPath(path);
-
-            _logger.Trace($"Downloading content {_url} / {path}");
-
             var partPath = path + ".part";
-            
-            try
+            await ExecuteWithRetriesAsync("download", path, partPath, fileSystem, cancellationToken, async () =>
             {
-                var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                _logger.Trace($"Downloading content {_url} / {path}");
+                using var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                 response.EnsureSuccessStatusCode();
                 await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
 
-                try
+                await using (var fileStream = await fileSystem.OpenWrite(partPath, cancellationToken))
                 {
-                    await using (var fileStream = await fileSystem.OpenWrite(partPath, cancellationToken))
-                    {
-                        await CopyToWithProgress(stream, fileStream, 10 * 1024 * 1024, progress, cancellationToken);
-                        fileStream.SetLength(fileStream.Position);
-                    } 
-                    // Get the hash of the file, use the extension from the original path to use the PBO logic 
-                    var entry = GetFileEntry(path) ?? throw new FileNotFoundException(path);
-                    var partRead = await fileSystem.OpenRead(partPath, cancellationToken) ?? throw new FileNotFoundException(partPath);
-                    if ((ulong)partRead.Length != entry.FileSize)
-                    {
-                        await partRead.DisposeAsync();
-                        throw new InvalidDataException(
-                            $"Size mismatch for {path}. Expected {entry.FileSize}, got {(ulong)partRead.Length}.");
-                    }
-                    var partHash = await Sha1AndPboHash.BuildAsync(partRead, Utils.GetExtension(path), cancellationToken);
-                    var expectedHash = new Sha1AndPboHash(entry.Hash);
-
-                    if (!partHash.Equals(expectedHash))
-                    {
-                        _logger.Warn($"Hash mismatch for {path}. Expected {expectedHash}, got {partHash}");
-                        await fileSystem.Delete(partPath, cancellationToken);
-                        throw new InvalidDataException($"Hash mismatch for {path}");
-                    }
-                    
-                    
-                    await fileSystem.Move(partPath, path, cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    _logger.Info($"Aborted downloading content {_url} / {partPath}");
-                    throw;
+                    await CopyToWithProgress(stream, fileStream, 10 * 1024 * 1024, progress, cancellationToken);
+                    fileStream.SetLength(fileStream.Position);
                 }
 
+                var entry = GetFileEntry(path) ?? throw new FileNotFoundException(path);
+                var partRead = await fileSystem.OpenRead(partPath, cancellationToken) ?? throw new FileNotFoundException(partPath);
+                if ((ulong)partRead.Length != entry.FileSize)
+                {
+                    await partRead.DisposeAsync();
+                    throw new InvalidDataException($"Size mismatch for {path}. Expected {entry.FileSize}, got {(ulong)partRead.Length}.");
+                }
+
+                var partHash = await Sha1AndPboHash.BuildAsync(partRead, Utils.GetExtension(path), cancellationToken);
+                var expectedHash = new Sha1AndPboHash(entry.Hash);
+                if (!partHash.Equals(expectedHash))
+                    throw new InvalidDataException($"Hash mismatch for {path}.");
+
+                await fileSystem.Move(partPath, path, cancellationToken);
                 _logger.Trace($"Finished downloading content {_url} / {partPath}");
-            }
-            catch (Exception e)
-            {
-                try
-                {
-                    await fileSystem.Delete(partPath, CancellationToken.None);
-                }
-                catch
-                {
-                    // best effort cleanup of temp files
-                }
-                _logger.Error(e, $"Error while trying to download {partPath}");
-                throw;
-            }
+            });
         }
 
         /// <summary>
@@ -247,48 +216,111 @@ namespace BSU.BSO
 
         public async Task UpdateTo(string path, IFileSystem fileSystem, IProgress<ulong> progress, CancellationToken cancellationToken)
         {
-            // TODO: retry
-            
             await _loading;
 
             _logger.Debug($"Updating file {_url} / {path}");
 
             var url = _url + GetRealPath(path);
-            await using var cfData = await _client.GetStreamAsync(url + ".zsync", cancellationToken);
-            var controlFile = new ControlFile(cfData);
-
-            var downloader = new RangeDownloader(new Uri(url), _client);
-
             var partPath = path + ".part";
-            var fileStream = await fileSystem.OpenWrite(partPath, cancellationToken);
-            var seed = await fileSystem.OpenRead(path, cancellationToken);
-
             try
             {
-
-                if (seed == null) throw new InvalidOperationException();
-                var syncProgress = new SyncProgress(progress.Report);
-                Zsync.Sync(controlFile, new List<Stream> { seed }, downloader, fileStream, syncProgress, cancellationToken);
-                fileStream.SetLength(fileStream.Position);
-                await seed.DisposeAsync();
-                await fileStream.DisposeAsync();
-
-                var extension = Utils.GetExtension(path).ToLowerInvariant();
-                if (extension == "pbo" || extension == "ebo")
+                await ExecuteWithRetriesAsync("update", path, partPath, fileSystem, cancellationToken, async () =>
                 {
-                    await VerifyWithControlFile(path, partPath, controlFile, fileSystem, cancellationToken);
-                }
+                    await using var cfData = await _client.GetStreamAsync(url + ".zsync", cancellationToken);
+                    var controlFile = new ControlFile(cfData);
+                    var downloader = new RangeDownloader(new Uri(url), _client);
+                    var syncProgress = new SyncProgress(progress.Report);
 
-                await fileSystem.Move(partPath, path, cancellationToken);
-                _logger.Debug($"Finished updating file {_url} / {path}");
+                    await using var fileStream = await fileSystem.OpenWrite(partPath, cancellationToken);
+                    await using var seed = await fileSystem.OpenRead(path, cancellationToken);
+                    if (seed == null) throw new InvalidOperationException();
+
+                    Zsync.Sync(controlFile, new List<Stream> { seed }, downloader, fileStream, syncProgress, cancellationToken);
+                    fileStream.SetLength(fileStream.Position);
+
+                    var extension = Utils.GetExtension(path).ToLowerInvariant();
+                    if (extension == "pbo" || extension == "ebo")
+                    {
+                        await VerifyWithControlFile(path, partPath, controlFile, fileSystem, cancellationToken);
+                    }
+
+                    await fileSystem.Move(partPath, path, cancellationToken);
+                    _logger.Debug($"Finished updating file {_url} / {path}");
+                });
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not OperationCanceledException)
             {
-                if (seed != null)
-                    await seed.DisposeAsync();
-                await fileStream.DisposeAsync();
-                _logger.Error(e, $"Error while syncing {_url} / {path}");
-                throw;
+                _logger.Warn($"Update failed for {path} after {_maxTransferAttempts} attempts; falling back to full download.");
+                await DownloadTo(path, fileSystem, progress, cancellationToken);
+            }
+        }
+
+        private async Task ExecuteWithRetriesAsync(string operation, string path, string partPath, IFileSystem fileSystem,
+            CancellationToken cancellationToken, Func<Task> action)
+        {
+            Exception? lastError = null;
+            for (int attempt = 1; attempt <= _maxTransferAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await CleanupPartFile(partPath, fileSystem);
+                try
+                {
+                    await action();
+                    return;
+                }
+                catch (Exception e) when (e is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                {
+                    await CleanupPartFile(partPath, fileSystem);
+                    throw;
+                }
+                catch (Exception e) when (IsRetryable(e, cancellationToken) && attempt < _maxTransferAttempts)
+                {
+                    lastError = e;
+                    _logger.Warn($"{operation} retry {attempt}/{_maxTransferAttempts} for {path}: {e.GetType().Name}");
+                    await CleanupPartFile(partPath, fileSystem);
+                    await Task.Delay(GetRetryDelay(attempt), cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    lastError = e;
+                    await CleanupPartFile(partPath, fileSystem);
+                    throw;
+                }
+            }
+
+            if (lastError != null)
+                throw lastError;
+        }
+
+        private static bool IsRetryable(Exception exception, CancellationToken cancellationToken)
+        {
+            if (exception is OperationCanceledException)
+                return !cancellationToken.IsCancellationRequested;
+            return exception is HttpRequestException or IOException or InvalidDataException;
+        }
+
+        private static TimeSpan GetRetryDelay(int attempt)
+        {
+            var jitter = Random.Shared.Next(0, 200);
+            var delayMs = attempt switch
+            {
+                1 => 300,
+                2 => 1000,
+                _ => 2500
+            };
+            return TimeSpan.FromMilliseconds(delayMs + jitter);
+        }
+
+        private static async Task CleanupPartFile(string partPath, IFileSystem fileSystem)
+        {
+            try
+            {
+                if (await fileSystem.HasFile(partPath, CancellationToken.None))
+                    await fileSystem.Delete(partPath, CancellationToken.None);
+            }
+            catch
+            {
+                // best effort cleanup
             }
         }
 

--- a/BSU.BSO/BsoRepoMod.cs
+++ b/BSU.BSO/BsoRepoMod.cs
@@ -255,8 +255,16 @@ namespace BSU.BSO
                 if (seed == null) throw new InvalidOperationException();
                 var syncProgress = new SyncProgress(progress.Report);
                 Zsync.Sync(controlFile, new List<Stream> { seed }, downloader, fileStream, syncProgress, cancellationToken);
+                fileStream.SetLength(fileStream.Position);
                 await seed.DisposeAsync();
                 await fileStream.DisposeAsync();
+
+                var extension = Utils.GetExtension(path).ToLowerInvariant();
+                if (extension == "pbo" || extension == "ebo")
+                {
+                    await VerifyWithControlFile(path, partPath, controlFile, fileSystem, cancellationToken);
+                }
+
                 await fileSystem.Move(partPath, path, cancellationToken);
                 _logger.Debug($"Finished updating file {_url} / {path}");
             }
@@ -268,6 +276,47 @@ namespace BSU.BSO
                 _logger.Error(e, $"Error while syncing {_url} / {path}");
                 throw;
             }
+        }
+
+        private static async Task VerifyWithControlFile(string path, string partPath, ControlFile controlFile,
+            IFileSystem fileSystem, CancellationToken cancellationToken)
+        {
+            var header = controlFile.GetHeader();
+            var localPart = await fileSystem.OpenRead(partPath, cancellationToken);
+            if (localPart == null) throw new FileNotFoundException(partPath);
+
+            await using (localPart)
+            {
+                if (localPart.Length != header.Length)
+                    throw new InvalidDataException(
+                        $"Zsync length mismatch for {path}: expected {header.Length}, got {localPart.Length}.");
+            }
+
+            // Verify pass: if any range download is required, the part file does not match the control file.
+            var verifyRead = await fileSystem.OpenRead(partPath, cancellationToken);
+            if (verifyRead == null) throw new FileNotFoundException(partPath);
+            await using (verifyRead)
+            {
+                Zsync.Sync(controlFile, new List<Stream> { verifyRead }, new NoDownloadRangeDownloader(path), Stream.Null, null,
+                    cancellationToken);
+            }
+        }
+
+        private sealed class NoDownloadRangeDownloader : IRangeDownloader
+        {
+            private readonly string _path;
+
+            public NoDownloadRangeDownloader(string path)
+            {
+                _path = path;
+            }
+
+            public Stream DownloadRange(long from, long to) =>
+                throw new InvalidDataException(
+                    $"Zsync verify failed for {_path}: unexpected range request [{from}, {to}).");
+
+            public Stream Download() =>
+                throw new InvalidDataException($"Zsync verify failed for {_path}: unexpected full download request.");
         }
 
         private class SyncProgress : IProgress<ulong>

--- a/BSU.BSO/BsoRepoMod.cs
+++ b/BSU.BSO/BsoRepoMod.cs
@@ -147,6 +147,7 @@ namespace BSU.BSO
 
         public async Task DownloadTo(string path, IFileSystem fileSystem, IProgress<ulong> progress, CancellationToken cancellationToken)
         {
+            
             // TODO: retry
             
             await _loading;
@@ -155,8 +156,8 @@ namespace BSU.BSO
 
             _logger.Trace($"Downloading content {_url} / {path}");
 
-            await using var fileStream = await fileSystem.OpenWrite(path, cancellationToken);
-
+            var partPath = path + ".part";
+            
             try
             {
                 var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
@@ -165,20 +166,38 @@ namespace BSU.BSO
 
                 try
                 {
-                    await CopyToWithProgress(stream, fileStream, 10 * 1024 * 1024, progress, cancellationToken);
+                    await using (var fileStream = await fileSystem.OpenWrite(partPath, cancellationToken))
+                    {
+                        await CopyToWithProgress(stream, fileStream, 10 * 1024 * 1024, progress, cancellationToken);
+                        fileStream.SetLength(fileStream.Position);
+                    } 
+                    // Get the hash of the file, use the extension from the original path to use the PBO logic 
+                    var entry = GetFileEntry(path) ?? throw new FileNotFoundException(path);
+                    var partRead = await fileSystem.OpenRead(partPath, cancellationToken) ?? throw new FileNotFoundException(partPath);
+                    var partHash = await Sha1AndPboHash.BuildAsync(partRead, Utils.GetExtension(path), cancellationToken);
+                    var expectedHash = new Sha1AndPboHash(entry.Hash);
+
+                    if (!partHash.Equals(expectedHash))
+                    {
+                        _logger.Warn($"Hash mismatch for {path}. Expected {expectedHash}, got {partHash}");
+                        await fileSystem.Delete(partPath, cancellationToken);
+                        throw new InvalidDataException($"Hash mismatch for {path}");
+                    }
+                    
+                    
+                    await fileSystem.Move(partPath, path, cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
-                    _logger.Info($"Aborted downloading content {_url} / {path}");
+                    _logger.Info($"Aborted downloading content {_url} / {partPath}");
                     throw;
                 }
 
-                fileStream.SetLength(fileStream.Position);
-                _logger.Trace($"Finished downloading content {_url} / {path}");
+                _logger.Trace($"Finished downloading content {_url} / {partPath}");
             }
             catch (Exception e)
             {
-                _logger.Error(e, $"Error while trying to download {path}");
+                _logger.Error(e, $"Error while trying to download {partPath}");
                 throw;
             }
         }

--- a/BSU.Core/Sync/RepoSync.cs
+++ b/BSU.Core/Sync/RepoSync.cs
@@ -42,7 +42,8 @@ namespace BSU.Core.Sync
                     var storageFileHash = await storage.GetFileHash(repoFile, cancellationToken);
                     
                     var repoFileSize = await repository.GetFileSize(repoFile, cancellationToken);
-                    var storageFileSize = (ulong) new FileInfo(Path.Combine(storage.Path, repoFile)).Length;
+                    await using var storageFile = await storage.OpenRead(repoFile, cancellationToken);
+                    var storageFileSize = (ulong)(storageFile?.Length ?? throw new FileNotFoundException(repoFile));
                     if (!repoFileHash.Equals(storageFileHash) || repoFileSize != storageFileSize)
                     {
                         allActions.Add(new UpdateAction(repository, storage, repoFile, repoFileSize));

--- a/BSU.Core/Sync/RepoSync.cs
+++ b/BSU.Core/Sync/RepoSync.cs
@@ -40,10 +40,12 @@ namespace BSU.Core.Sync
                 {
                     var repoFileHash = await repository.GetFileHash(repoFile, cancellationToken);
                     var storageFileHash = await storage.GetFileHash(repoFile, cancellationToken);
-                    if (!repoFileHash.Equals(storageFileHash))
+                    
+                    var repoFileSize = await repository.GetFileSize(repoFile, cancellationToken);
+                    var storageFileSize = (ulong) new FileInfo(Path.Combine(storage.Path, repoFile)).Length;
+                    if (!repoFileHash.Equals(storageFileHash) || repoFileSize != storageFileSize)
                     {
-                        var fileSize = await repository.GetFileSize(repoFile, cancellationToken);
-                        allActions.Add(new UpdateAction(repository, storage, repoFile, fileSize));
+                        allActions.Add(new UpdateAction(repository, storage, repoFile, repoFileSize));
                         storageListCopy.Remove(repoFile + ".part");
                     }
 

--- a/BSU/App.xaml.cs
+++ b/BSU/App.xaml.cs
@@ -25,8 +25,9 @@ namespace BSU.GUI
 
             var branchFilePath = Path.Combine(parentPath, "branch");
             var squirrel = new SquirrelHelper(branchFilePath);
-
+#if !DEBUG
             squirrel.HandleEvents();
+#endif
             base.OnStartup(startupEventArgs);
             var mainWindow = new MainWindow();
             Thread.CurrentThread.Name = "main";


### PR DESCRIPTION
Adds 
- zsync checks when downloading whole files to trap corrupted PBOs with valid tail hashes 
- size checking alongside hash checking (slightly redundant, but doesnt hurt) 
- **retry logic** files will be tried 3 times if they fail (with delay + jitter), update files will fall back to full download eventually 